### PR TITLE
Auto-mount USB storage using autofs

### DIFF
--- a/debian-base-image-rpi4.yml
+++ b/debian-base-image-rpi4.yml
@@ -111,6 +111,14 @@ actions:
       image: {{ $image }}
 
   - action: recipe
+    recipe: recipes/30-autofs.yml
+    variables:
+      architecture: {{ $architecture }}
+      firmware_version: {{ $firmware_version }}
+      suite: {{ $suite }}
+      image: {{ $image }}
+
+  - action: recipe
     recipe: recipes/90-base-finalscripts.yml
     variables:
       architecture: {{ $architecture }}

--- a/overlays/30-autofs/etc/auto.master
+++ b/overlays/30-autofs/etc/auto.master
@@ -1,0 +1,40 @@
+#
+# Sample auto.master file
+# This is a 'master' automounter map and it has the following format:
+# mount-point [map-type[,format]:]map [options]
+# For details of the format look at auto.master(5).
+#
+#/misc  /etc/auto.misc
+#
+# NOTE: mounts done from a hosts map will be mounted with the
+#       "nosuid" and "nodev" options unless the "suid" and "dev"
+#       options are explicitly given.
+#
+#/net   -hosts
+#
+# Include /etc/auto.master.d/*.autofs
+# To add an extra map using this mechanism you will need to add
+# two configuration items - one /etc/auto.master.d/extra.autofs file
+# (using the same line format as the auto.master file)
+# and a separate mount map (e.g. /etc/auto.extra or an auto.extra NIS map)
+# that is referred to by the extra.autofs file.
+#
++dir:/etc/auto.master.d
+#
+# If you have fedfs set up and the related binaries, either
+# built as part of autofs or installed from another package,
+# uncomment this line to use the fedfs program map to access
+# your fedfs mounts.
+#/nfs4  /usr/sbin/fedfs-map-nfs4 nobind
+#
+# Include central master map if it can be found using
+# nsswitch sources.
+#
+# Note that if there are entries for /net or /misc (as
+# above) in the included master map any keys that are the
+# same will not be seen as the first read key seen takes
+# precedence.
+#
++auto.master
+
+/media/   /etc/auto.usb --timeout=10,defaults,user,exec,uid=1000

--- a/overlays/30-autofs/etc/auto.usb
+++ b/overlays/30-autofs/etc/auto.usb
@@ -1,0 +1,1 @@
+sdb    -fstype=auto    :/dev/sdb1

--- a/recipes/30-autofs.yml
+++ b/recipes/30-autofs.yml
@@ -1,0 +1,16 @@
+{{- $architecture := or .architecture "arm64" -}}
+{{- $firmware_version := or .firmware_version "master" -}}
+{{ $suite :=  or .suite "focal" }}
+{{- $image := or .image "ovos-dev-edition-rpi4.img" -}}
+
+architecture: {{ $architecture }}
+
+actions:
+  - action: apt
+    description: Autofs
+    packages:
+      - autofs
+  - action: overlay
+    description: Autofs overlay
+    source: ../overlays/30-autofs
+    destination: /


### PR DESCRIPTION
# Description
Add autofs with config to auto-mount one connected external drive

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This can likely be achieved better using udev rules