### PR TITLE
Make build-time parameters configurable and align output image partitions

### DIFF
--- a/debian-base-image-rpi4.yml
+++ b/debian-base-image-rpi4.yml
@@ -2,6 +2,7 @@
 {{- $firmware_version := or .firmware_version "master" -}}
 {{ $suite :=  or .suite "bookworm" }}
 {{- $image := or .image "debian-base-image-rpi4" -}}
+{{- $build_cores := or .build_cores 4 -}}
 
 architecture: {{ $architecture }}
 
@@ -116,22 +117,19 @@ actions:
     recipe: recipes/15-firmware-updates.yml
     variables:
       architecture: {{ $architecture }}
+      build_cores: {{ $build_cores }}
 
   - action: recipe
     recipe: recipes/16-python-3_10.yml
     variables:
       architecture: {{ $architecture }}
-      firmware_version: {{ $firmware_version }}
-      suite: {{ $suite }}
-      image: {{ $image }}
+      build_cores: {{ $build_cores }}
 
   - action: recipe
     recipe: recipes/20-sj201.yml
     variables:
       architecture: {{ $architecture }}
-      firmware_version: {{ $firmware_version }}
-      suite: {{ $suite }}
-      image: {{ $image }}
+      build_cores: {{ $build_cores }}
 
   - action: recipe
     recipe: recipes/90-base-finalscripts.yml
@@ -161,6 +159,5 @@ actions:
     recipe: recipes/99-finalize_squashfs.yml
     variables:
       architecture: {{ $architecture }}
-      firmware_version: {{ $firmware_version }}
-      suite: {{ $suite }}
       image: {{ $image }}
+      build_cores: {{ $build_cores }}

--- a/debian-neon-image-rpi4.yml
+++ b/debian-neon-image-rpi4.yml
@@ -3,6 +3,7 @@
 {{ $suite :=  or .suite "bookworm" }}
 {{- $image := or .image "debian-neon-image-rpi4" -}}
 {{- $neon_core := or .neon_core "master" -}}
+{{- $build_cores := or .build_cores 4 -}}
 
 architecture: {{ $architecture }}
 
@@ -122,25 +123,19 @@ actions:
     recipe: recipes/16-python-3_10.yml
     variables:
       architecture: {{ $architecture }}
-      firmware_version: {{ $firmware_version }}
-      suite: {{ $suite }}
-      image: {{ $image }}
+      build_cores: {{ $build_cores }}
 
   - action: recipe
     recipe: recipes/20-sj201.yml
     variables:
       architecture: {{ $architecture }}
-      firmware_version: {{ $firmware_version }}
-      suite: {{ $suite }}
-      image: {{ $image }}
+      build_cores: {{ $build_cores }}
 
   - action: recipe
     recipe: recipes/30-ovos-shell.yml
     variables:
       architecture: {{ $architecture }}
-      firmware_version: {{ $firmware_version }}
-      suite: {{ $suite }}
-      image: {{ $image }}
+      build_cores: {{ $build_cores }}
 
   - action: recipe
     recipe: recipes/31-updater-service.yml
@@ -211,8 +206,6 @@ actions:
     recipe: recipes/95-add_metadata.yml
     variables:
       architecture: {{ $architecture }}
-      firmware_version: {{ $firmware_version }}
-      suite: {{ $suite }}
       image: {{ $image }}
       neon_core: {{ $neon_core }}
 
@@ -228,6 +221,5 @@ actions:
     recipe: recipes/99-finalize_squashfs.yml
     variables:
       architecture: {{ $architecture }}
-      firmware_version: {{ $firmware_version }}
-      suite: {{ $suite }}
       image: {{ $image }}
+      build_cores: {{ $build_cores }}

--- a/recipes/16-python-3_10.yml
+++ b/recipes/16-python-3_10.yml
@@ -1,5 +1,5 @@
 {{- $architecture := or .architecture "arm64" -}}
-{{ $suite :=  or .suite "bullseye" }}
+{{- $build_cores := or .build_cores 4 -}}
 
 architecture: {{ $architecture }}
 
@@ -28,4 +28,4 @@ actions:
   - action: run
     description: Build Python 3.10
     chroot: true
-    script: ../scripts/16-build_python_3_10.sh
+    script: ../scripts/16-build_python_3_10.sh {{ $build_cores }}

--- a/recipes/20-sj201.yml
+++ b/recipes/20-sj201.yml
@@ -1,6 +1,6 @@
 {{- $architecture := or .architecture "arm64" -}}
-{{- $firmware_version := or .firmware_version "master" -}}
-{{ $suite :=  or .suite "focal" }}
+{{- $build_cores := or .build_cores 4 -}}
+
 
 architecture: {{ $architecture }}
 
@@ -23,4 +23,4 @@ actions:
   - action: run
     description: Build and Install SJ201 VF driver
     chroot: true
-    script: ../scripts/20-setup-sj201.sh
+    script: ../scripts/20-setup-sj201.sh {{ $build_cores }}

--- a/recipes/30-ovos-shell.yml
+++ b/recipes/30-ovos-shell.yml
@@ -1,6 +1,5 @@
 {{- $architecture := or .architecture "arm64" -}}
-{{- $firmware_version := or .firmware_version "master" -}}
-{{ $suite :=  or .suite "focal" }}
+{{- $build_cores := or .build_cores 4 -}}
 
 architecture: {{ $architecture }}
 
@@ -33,4 +32,4 @@ actions:
   - action: run
     description: Build and Install OVOS Shell and Mycroft GUI
     chroot: true
-    script: ../scripts/30-build-ovos-shell.sh
+    script: ../scripts/30-build-ovos-shell.sh {{ $build_cores }}

--- a/recipes/95-add_metadata.yml
+++ b/recipes/95-add_metadata.yml
@@ -1,6 +1,4 @@
 {{- $architecture := or .architecture "arm64" -}}
-{{- $firmware_version := or .firmware_version "master" -}}
-{{ $suite :=  or .suite "focal" }}
 {{- $image := or .image "ovos-dev-edition-rpi4" -}}
 {{- $neon_core := or .neon_core "master" -}}
 

--- a/recipes/99-finalize_squashfs.yml
+++ b/recipes/99-finalize_squashfs.yml
@@ -1,7 +1,6 @@
 {{- $architecture := or .architecture "arm64" -}}
-{{- $firmware_version := or .firmware_version "master" -}}
-{{ $suite :=  or .suite "focal" }}
 {{- $image := or .image "ovos-dev-edition-rpi4" -}}
+{{- $build_cores := or .build_cores 4 -}}
 
 architecture: {{ $architecture }}
 
@@ -21,11 +20,12 @@ actions:
     partitions:
       - name: firmware
         fs: fat32
-        start: 0%
-        end: 256MB
+        start: 1048576B
+        end: 268435455B
+        # About 256MiB, but aligned for expected sector size
       - name: root
         fs: ext4
-        start: 256MB
+        start: 268435456B
         end: 100%
 
   - action: run
@@ -41,4 +41,4 @@ actions:
   - action: run
     description: Compress image
     postprocess: true
-    command: xz --compress -T0 output/{{ $image }}.img
+    command: xz --compress -T{{ $build_cores }} output/{{ $image }}.img

--- a/run_docker_debos.sh
+++ b/run_docker_debos.sh
@@ -7,6 +7,8 @@ source_dir="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 timestamp=$(date '+%Y-%m-%d_%H_%M')
 image=${1:-"debian-neon-image-rpi4.yml"}
 neon_core=${2:-"master"}
+mem_limit=${MEM_LIMIT:-"16G"}
+core_limit=${CORE_LIMIT:-4}
 echo "${pass}" | sudo -S chmod ugo+x "${source_dir}/scripts/"*
 docker run --rm -d \
 --device /dev/kvm \
@@ -15,7 +17,7 @@ docker run --rm -d \
 --group-add=108 \
 --security-opt label=disable \
 --name neon_debos \
-godebos/debos "${image}" -t architecture:arm64 -t image:"${image%.*}_${timestamp}" -t neon_core:"${neon_core}" -m 24G -c 4 && \
+godebos/debos "${image}" -t architecture:arm64 -t image:"${image%.*}_${timestamp}" -t neon_core:"${neon_core}" -t build_cores:"${core_limit}" -m "${mem_limit}" -c "${core_limit}" && \
 docker logs -f neon_debos
 echo "completed ${timestamp}"
 echo "${pass}" | sudo -S chown $USER:$USER "${source_dir}/output/${image%.*}_${timestamp}"*

--- a/scripts/06-libcamera.sh
+++ b/scripts/06-libcamera.sh
@@ -30,25 +30,6 @@
 # Set to exit on error
 set -Ee
 
-## Clone and build libcamera
-#git clone https://github.com/raspberrypi/libcamera.git
-#cd libcamera || exit 10
-#meson setup build -Dv4l2=true -Dtest=false -Dlc-compliance=disabled -Dcam=disabled -Dqcam=disabled -Ddocumentation=disabled
-#ninja -C build install
-#cd ..
-#rm -rf libcamera
-#
-## Clone and build libepoxy
-#git clone https://github.com/anholt/libepoxy.git
-#cd libepoxy || exit 10
-#mkdir _build
-#cd _build || exit 10
-#meson setup
-#ninja
-#ninja install
-#cd ../..
-#rm -rf libepoxy
-
 # Clone and build libcamera-apps
 git clone https://github.com/raspberrypi/libcamera-apps.git -b v1.2.1
 cd libcamera-apps || exit 10

--- a/scripts/16-build_python_3_10.sh
+++ b/scripts/16-build_python_3_10.sh
@@ -36,7 +36,7 @@ tar -xf Python-3.10.0.tar.xz
 rm Python-3.10.0.tar.xz
 cd Python-3.10.0 || exit 10
 ./configure --enable-optimizations && echo "Configure complete"
-make -j4 && echo "make complete"
+make -j${1:-} && echo "make complete"
 make altinstall && echo "install complete"
 rm -rf /opt/Python-3.10.0
 

--- a/scripts/20-setup-sj201.sh
+++ b/scripts/20-setup-sj201.sh
@@ -66,7 +66,7 @@ fi
 git clone https://github.com/OpenVoiceOS/vocalfusiondriver
 cd vocalfusiondriver/driver || exit 10
 sed -ie "s|\$(shell uname -r)|${kernel}|g" Makefile
-make all || exit 2
+make -j${1:-} all || exit 2
 mkdir -p "/lib/modules/${kernel}/kernel/drivers/vocalfusion"
 cp vocalfusion* "/lib/modules/${kernel}/kernel/drivers/vocalfusion" || exit 2
 cd ../..

--- a/scripts/30-build-ovos-shell.sh
+++ b/scripts/30-build-ovos-shell.sh
@@ -40,7 +40,7 @@ mv /opt/neon/neon_logo.svg ovos-shell/application/icons/ovos-egg.svg
 cd ovos-shell || exit 10
 cmake .
 bash prefix.sh
-make ovos-shell
+make -j${1:-} ovos-shell
 make install ovos-shell || exit 10
 cd "${BASE_DIR}" || exit 10
 rm -rf ovos-shell
@@ -58,7 +58,7 @@ if [[ ! -d build-testing ]] ; then
 fi
 cd build-testing || exit 10
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
-make -j2
+make -j${1:-}
 make install
 
 # TODO: This can be moved to debos recipe
@@ -75,7 +75,7 @@ fi
 
 cd build || exit 10
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DKDE_INSTALL_LIBDIR=lib -DKDE_INSTALL_USE_QT_SYS_PATHS=ON
-make -j2
+make -j${1:-}
 make install
 
 cd "${BASE_DIR}" || exit 10


### PR DESCRIPTION
# Description
Add `build_cores` configurable parameter and update `make` calls to respect this
Align partitions in output image to match expected sector size Remove deprecated code
Read core and memory limits from env in `run_docker_debos.sh`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->