### PR TITLE
Add usbutils to developer extras

### DIFF
--- a/recipes/70-developer-extras.yml
+++ b/recipes/70-developer-extras.yml
@@ -9,3 +9,4 @@ actions:
       - less
       - iputils-ping
       - htop
+      - usbutils


### PR DESCRIPTION
# Description
Adds `usbutils` to provide `lsusb`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Discussed [on Matrix](https://matrix.to/#/!ZhEZYNzKBfpEAhtQIz:matrix.org/$Uj4Mtfb9JhnT_Di-rE5OOL_JgyEaa1cvfnHMPiZB-dU?via=matrix.org&via=nitro.chat&via=tomesh.net)