### PR TITLE
Resolve KDEConnect init errors

### DIFF
--- a/overlays/46-audio-receiver/usr/lib/systemd/system/kdeconnect.service
+++ b/overlays/46-audio-receiver/usr/lib/systemd/system/kdeconnect.service
@@ -1,16 +1,17 @@
 [Unit]
 Description=KDEConnect Daemon
 Documentation=https://kdeconnect.kde.org/
-After=network.target
+After=network-online.target
+After=dbus.service
+StartLimitIntervalSec=300s
+StartLimitBurst=3
 
 [Service]
 User=neon
 EnvironmentFile=/etc/neon/neon_env.conf
 ExecStart=/usr/lib/aarch64-linux-gnu/libexec/kdeconnectd --platform offscreen
 Restart=on-failure
-RestartSec=5s
-StartLimitInterval=60s
-StartLimitBurst=3
+RestartSec=30s
 
 # Restart the service if it's unexpectedly stopped
 RestartPreventExitStatus=SIGINT SIGTERM


### PR DESCRIPTION
# Description
Update kdeconnect service for better startup exception handling

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
This isn't perfect as the service still often fails because the `/run/user/<UID>` directory is not yet present. I think in the future this may be a user service but this is a larger consideration for Neon Core and other services as well