### PR TITLE
Update base images and fix OPi5 automation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 rpi4_base.tar.gz filter=lfs diff=lfs merge=lfs -text
+opi5_base.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/rpi4_base.tar.gz
+++ b/rpi4_base.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36f69ebb15d0abdfa605b42f574a9bbf732a7f244a760c78b77215ae070b6d98
-size 1100062557
+oid sha256:3dacc5c77f5484f99179fc424d93d7e6411274db8a3d5af0efe36e527f145af9
+size 1094748531

--- a/run_automation.sh
+++ b/run_automation.sh
@@ -45,7 +45,7 @@ debos_version="$(python3 "${source_dir}/version.py")"
 
 if [ ! -f "${source_dir}/${platform}_base.tar.gz" ]; then
   echo "WARNING: Building ${platform} base image"
-  bash "${source_dir}/build_base_image.sh" "${platform]}"
+  bash "${source_dir}/build_base_image.sh" "${platform}"
   echo "Completed ${platform} base image"
 fi
 


### PR DESCRIPTION
# Description
Adds missing opi5 base image
Updates ovos-shell in images to account for message session changes
Fixes typo in automation script to allow handling missing base images

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->