### PR TITLE
Fix missing `neon_core` variable

### DIFF
--- a/debian-neon-image.yml
+++ b/debian-neon-image.yml
@@ -41,6 +41,7 @@ actions:
     variables:
       architecture: {{ $architecture }}
       device: {{ $device }}
+      neon_core: {{ $neon_core }}
 
   - action: recipe
     recipe: recipes/45-reset-service.yml


### PR DESCRIPTION
# Description
Fixes refactor that removed `neon_core` from the relevant build recipe, causing builds to always default to `master`

# Issues
Fixes bug introduced in #39

# Other Notes
Bug noted in [Neon OS Automation run](https://github.com/NeonGeckoCom/neon-os/actions/runs/8071674720/job/22051795696)