### PR TITLE
Improved Time Handling

### DIFF
--- a/base_images/base_images.md5
+++ b/base_images/base_images.md5
@@ -1,2 +1,2 @@
-cfb0bbe8b69583fbc661be0c14e24983  opi5_base.tar.gz
-86c820f1c8601b73eb36272b9bad6aad  rpi4_base.tar.gz
+a5f5e57d42846e155fd5f6ed1b7cc363  opi5_base.tar.gz
+31e2d9fa66ae45d1c29c84e6c2e34c69  rpi4_base.tar.gz

--- a/overlays/16-boot-network-config/usr/lib/systemd/system/check-boot-network-config.service
+++ b/overlays/16-boot-network-config/usr/lib/systemd/system/check-boot-network-config.service
@@ -3,6 +3,7 @@ Description=Boot Partition Network Configuration Check
 Requires=network.target
 After=NetworkManager.service
 Before=wifi-setup.service
+Before=update-clock.service
 
 [Service]
 Restart=on-failure

--- a/overlays/16-boot-network-config/usr/lib/systemd/system/check-boot-network-config.service
+++ b/overlays/16-boot-network-config/usr/lib/systemd/system/check-boot-network-config.service
@@ -6,6 +6,7 @@ Before=wifi-setup.service
 Before=update-clock.service
 
 [Service]
+Type=oneshot
 Restart=on-failure
 RestartSec=15s
 ExecStart=/bin/bash /opt/neon/check_boot_network_config.sh

--- a/overlays/27-update-clock/opt/neon/check_clock.sh
+++ b/overlays/27-update-clock/opt/neon/check_clock.sh
@@ -43,7 +43,13 @@ if [ $? != 0 ]; then
 fi
 if [ $? != 0 ]; then
   echo "Network not connected."
+  if [ -f "/opt/neon/reset_clock" ]; then
+    echo "Reset time on first boot without networking"
+    /usr/bin/date -s "1 JAN 1970 00:00:00"
+  fi
 else
   echo "Connected; force sync"
   /usr/sbin/ntpd -ngq
 fi
+
+[ -f "/opt/neon/reset_clock" ] && rm /opt/neon/reset_clock

--- a/overlays/27-update-clock/opt/neon/check_clock.sh
+++ b/overlays/27-update-clock/opt/neon/check_clock.sh
@@ -42,8 +42,7 @@ if [ $? != 0 ]; then
     ip route | grep default
 fi
 if [ $? != 0 ]; then
-  echo "Network not connected, reset time"
-  /usr/bin/date -s "1 JAN 1970 00:00:00"
+  echo "Network not connected."
 else
   echo "Connected; force sync"
   /usr/sbin/ntpd -ngq

--- a/overlays/42-neon-node/usr/lib/systemd/system/neon-node.service
+++ b/overlays/42-neon-node/usr/lib/systemd/system/neon-node.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Neon Node Service
-After=ntpd.service
+After=update-clock.service
 
 [Service]
 Type=notify

--- a/recipes/17-locale-config.yml
+++ b/recipes/17-locale-config.yml
@@ -17,3 +17,11 @@ actions:
     command: |
       dpkg-reconfigure --frontend=noninteractive locales
       update-locale LANG=en_US.UTF-8
+
+  - action: run
+    description: Set default timezone
+    chroot: true
+    command: |
+      echo "America/Los_Angeles" > /etc/timezone
+      rm /etc/localtime
+      ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime

--- a/recipes/95-add_metadata.yml
+++ b/recipes/95-add_metadata.yml
@@ -4,10 +4,16 @@
 {{- $neon_debos := or .neon_debos "unknown" -}}
 {{ $platform := or .platform "rpi4" }}
 {{ $device := or .device $platform }}
+{{ $hostname := or .hostname "neon" }}
 
 architecture: {{ .architecture }}
 
 actions:
+  - action: run
+    descripion: Update OS hostname
+    chroot: true
+    command: echo "{{ $hostname }}" > /etc/hostname
+
   - action: run
     description: Add metadata file to image
     chroot: true

--- a/scripts/40-configure-default-user.sh
+++ b/scripts/40-configure-default-user.sh
@@ -32,8 +32,6 @@ cd "${BASE_DIR}" || exit 10
 
 default_username="neon"  # Default user to create
 default_password="neon"
-image_name="neon"  # Identifier for extra directories and hostname
-
 
 # Add 'neon' user with default password
 adduser "${default_username}" --gecos "" --disabled-password
@@ -59,12 +57,4 @@ usermod -aG i2c ${default_username}
 usermod -aG dialout ${default_username}
 usermod -aG netdev ${default_username}
 
-
-# Set TZ
-echo "America/Los_Angeles" > /etc/timezone
-rm /etc/localtime
-ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
-
-  echo "${image_name}" > /etc/hostname
-
-echo "Core Configuration Complete"
+echo "User configuration complete"


### PR DESCRIPTION
# Description
Refactor to support offline systems with RTC
Update neon-node init to ensure clock update before service startup
Refactor time and hostname setting out of user recipe and into relevant recipes

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->