### PR TITLE
Handle a `build_version` arg for image metadata "version"

### DIFF
--- a/debian-base-image.yml
+++ b/debian-base-image.yml
@@ -5,6 +5,7 @@
 {{- $image := or .image "debian-base-image-rpi4" -}}
 {{- $neon_debos := or .neon_debos "unknown" -}}
 {{- $build_cores := or .build_cores 4 -}}
+{{ $build_version := or .build_version "" }}
 
 architecture: {{ $architecture }}
 

--- a/debian-neon-image.yml
+++ b/debian-neon-image.yml
@@ -8,6 +8,7 @@
 {{- $neon_debos := or .neon_debos "unknown" -}}
 {{- $build_cores := or .build_cores 4 -}}
 {{- $librespot_name := or .librespot_name  "Neon Mark 2" }}
+{{ $build_version := or .build_version "" }}
 
 architecture: {{ $architecture }}
 
@@ -83,6 +84,7 @@ actions:
       neon_debos: {{ $neon_debos }}
       platform: {{ $platform }}
       device: {{ $device }}
+      build_version: {{ $build_version }}
 
   - action: recipe
     recipe: recipes/98-backup-image.yml

--- a/debian-node-image.yml
+++ b/debian-node-image.yml
@@ -8,6 +8,7 @@
 {{- $neon_core := or .neon_core "master" -}}
 {{- $neon_debos := or .neon_debos "unknown" -}}
 {{- $build_cores := or .build_cores 4 -}}
+{{ $build_version := or .build_version "" }}
 
 architecture: {{ $architecture }}
 
@@ -70,6 +71,7 @@ actions:
       neon_debos: {{ $neon_debos }}
       platform: {{ $platform }}
       device: {{ $device }}
+      build_version: {{ $build_version }}
 
   - action: recipe
     recipe: recipes/98-backup-image.yml

--- a/recipes/95-add_metadata.yml
+++ b/recipes/95-add_metadata.yml
@@ -5,6 +5,7 @@
 {{ $platform := or .platform "rpi4" }}
 {{ $device := or .device $platform }}
 {{ $hostname := or .hostname "neon" }}
+{{ $build_version := or .build_version "" }}
 
 architecture: {{ .architecture }}
 
@@ -17,7 +18,7 @@ actions:
   - action: run
     description: Add metadata file to image
     chroot: true
-    script: ../scripts/95-get_metadata.py {{ $neon_core }} {{ $neon_debos }} {{ $image }} {{ $architecture }} {{ $platform }} {{ $device }}
+    script: ../scripts/95-get_metadata.py {{ $neon_core }} {{ $neon_debos }} {{ $image }} {{ $architecture }} {{ $platform }} {{ $device }} {{ $build_version }}
   - action: run
     description: Copy metadata to outputs
     chroot: false

--- a/scripts/95-get_metadata.py
+++ b/scripts/95-get_metadata.py
@@ -128,11 +128,11 @@ if __name__ == "__main__":
     architecture = argv[4]
     platform = argv[5]
     device = argv[6]
-    version = argv[7] or (image_name.split('_', 1)[1].replace("20", "", 1) +
+    build_version = argv[7] or (image_name.split('_', 1)[1].replace("20", "", 1) +
                           "alpha")
 
     print(f"debos_ref={debos_ref}")
-    data = {"version": version}
+    data = {"build_version": build_version}
 
     if image_name.startswith("debian-neon-image"):
         edition = "Core"

--- a/scripts/95-get_metadata.py
+++ b/scripts/95-get_metadata.py
@@ -86,8 +86,14 @@ def get_recipe_meta(branch="dev"):
 
 
 def get_initramfs_metadata():
-    initramfs_path = "/boot/firmware/initramfs"
+    if platform == "rpi4":
+        initramfs_path = "/boot/firmware/initramfs"
+    elif platform == "opi5":
+        initramfs_path = "/boot/uInitrd"
+    else:
+        return dict()
     if not os.path.isfile(initramfs_path):
+        print(f"Missing initramfs at: {initramfs_path}")
         return dict()
     else:
         with open(initramfs_path, 'rb') as f:
@@ -122,16 +128,20 @@ if __name__ == "__main__":
     architecture = argv[4]
     platform = argv[5]
     device = argv[6]
+    version = argv[7] or (image_name.split('_', 1)[1].replace("20", "", 1) +
+                          "alpha")
 
     print(f"debos_ref={debos_ref}")
-    data = dict()
+    data = {"version": version}
 
     if image_name.startswith("debian-neon-image"):
         edition = "Core"
-        data["core"] = get_neon_core_meta(core_ref, "NeonCore", "neon_core/version.py")
+        data["core"] = get_neon_core_meta(core_ref, "NeonCore",
+                                          "neon_core/version.py")
     elif image_name.startswith("debian-node-image"):
         edition = "Node"
-        data["core"] = get_neon_core_meta(core_ref, "neon-nodes", "neon_nodes/version.py")
+        data["core"] = get_neon_core_meta(core_ref, "neon-nodes",
+                                          "neon_nodes/version.py")
     else:
         edition = "Unknown"
 


### PR DESCRIPTION
# Description
Handle `build_version` variable and add to `build_info.json`
Fixes error in opi5 initramFS path

# Issues
Enables https://github.com/NeonGeckoCom/neon-os/issues/3

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->