### PR TITLE
Fix default `build_version` handling

### DIFF
--- a/scripts/95-get_metadata.py
+++ b/scripts/95-get_metadata.py
@@ -131,8 +131,7 @@ if __name__ == "__main__":
     if len(argv) > 7:
         build_version = argv[7]
     else:
-        build_version = image_name.split('_',
-                                         1)[1].replace("20", "", 1) + "alpha"
+        build_version = image_name.split('_')[1][2:].replace('-', '.') + "alpha"
 
     print(f"debos_ref={debos_ref}")
     data = {"build_version": build_version}

--- a/scripts/95-get_metadata.py
+++ b/scripts/95-get_metadata.py
@@ -128,8 +128,11 @@ if __name__ == "__main__":
     architecture = argv[4]
     platform = argv[5]
     device = argv[6]
-    build_version = argv[7] or (image_name.split('_', 1)[1].replace("20", "", 1) +
-                          "alpha")
+    if len(argv) > 7:
+        build_version = argv[7]
+    else:
+        build_version = image_name.split('_',
+                                         1)[1].replace("20", "", 1) + "alpha"
 
     print(f"debos_ref={debos_ref}")
     data = {"build_version": build_version}


### PR DESCRIPTION
# Description
Update logic in `get_metadata` to handle null `build_version` for backwards-compat.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Failure noted https://github.com/NeonGeckoCom/NeonCore/actions/runs/8117323460/job/22189242012