### PR TITLE
Add automation to trigger Neon OS beta builds

### DIFF
--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -20,3 +20,18 @@ jobs:
       publish_pypi: false
       publish_prerelease: true
       update_changelog: true
+  trigger_os_build:
+    runs-on: ubuntu-latest
+    needs: publish_alpha_release
+    steps:
+      - name: Call Release Action
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{secrets.NEON_OS_TOKEN}}
+          repository: neongeckocom/neon-os
+          event-type: Publish Release
+          client-payload: |-
+            {
+              "ref": "dev",
+              "repo": "neon-debos"
+            }


### PR DESCRIPTION
# Description
Adds an automation trigger to run Neon OS builds on merge to `dev`

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->