### PR TITLE
Refactor service dependencies to optimize startup

### DIFF
--- a/base_images/base_images.md5
+++ b/base_images/base_images.md5
@@ -1,2 +1,2 @@
-efd7e546eca9420b6106b1cd879f4be8  opi5_base.tar.gz
-c33e1967539b4248cb12d0443540fb02  rpi4_base.tar.gz
+ef22352165668b3b112c31ff59a3274c  opi5_base.tar.gz
+9879264b40ccbba956354384a6f8e346  rpi4_base.tar.gz

--- a/overlays/20-sj201/usr/lib/systemd/system/sj201-reset.service
+++ b/overlays/20-sj201/usr/lib/systemd/system/sj201-reset.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=SJ201 Boot Check for Reset Service
 After=sj201.service
-After=multi-user.target
+After=basic.target
 
 [Service]
 Type=oneshot

--- a/overlays/29-ovos-shell/usr/lib/systemd/system/gui-shell.service
+++ b/overlays/29-ovos-shell/usr/lib/systemd/system/gui-shell.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Neon GUI
+Before=neon.service
+After=basic.target
 
 [Service]
 # TODO: Generic user ID
@@ -12,4 +14,4 @@ Restart=on-failure
 TimeoutStopSec=10
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=graphical.target

--- a/overlays/41-neon-core/usr/lib/systemd/system/neon.service
+++ b/overlays/41-neon-core/usr/lib/systemd/system/neon.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Neon A.I. Software stack.
 After=pulseaudio.service
-After=gui-shell.service
 After=preflight-check.service
 After=basic.target
 

--- a/overlays/41-neon-core/usr/lib/systemd/system/neon.service
+++ b/overlays/41-neon-core/usr/lib/systemd/system/neon.service
@@ -3,6 +3,7 @@ Description=Neon A.I. Software stack.
 After=pulseaudio.service
 After=gui-shell.service
 After=preflight-check.service
+After=basic.target
 
 [Service]
 Type=oneshot

--- a/scripts/13-audio-devices.sh
+++ b/scripts/13-audio-devices.sh
@@ -51,6 +51,12 @@ rm -rf /tmp/tinyalsa
 # Clone and install ovos-i2csound
 cd /tmp
 git clone https://github.com/openvoiceos/ovos-i2csound
+
+# Patching compat with Kernel 6.6-specific changes
+cd ovos-i2csound
+git reset --hard 7215db7
+cd ..
+
 cp ovos-i2csound/i2c.conf /etc/modules-load.d/
 cp ovos-i2csound/ovos-i2csound /usr/libexec/
 cp ovos-i2csound/99-i2c.rules /usr/lib/udev/rules.d/


### PR DESCRIPTION
# Description
Updates services to allow more services to start earlier with more precise dependencies

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Pins a specific commit of ovos-i2csound to retain Kernel 6.1 support