### PR TITLE
Ensure Clock is synced during init

### DIFF
--- a/base_images/base_images.md5
+++ b/base_images/base_images.md5
@@ -1,2 +1,2 @@
-ef22352165668b3b112c31ff59a3274c  opi5_base.tar.gz
-9879264b40ccbba956354384a6f8e346  rpi4_base.tar.gz
+d1e3dc7f96ae04d7778a6062e4c5adb3  opi5_base.tar.gz
+08b1e50a3bc9d51988f4eabc15319ce3  rpi4_base.tar.gz

--- a/overlays/27-update-clock/opt/neon/check_clock
+++ b/overlays/27-update-clock/opt/neon/check_clock
@@ -30,26 +30,27 @@
 # Do nothing if there's an RTC module present
 [ -e /dev/rtc ] && exit 0
 
-ip route | grep default
 
-if [ $? != 0 ]; then
+if ! grep "default" <<< "$(ip route)"; then
     if [ -n "$(ls /etc/NetworkManager/system-connections/)" ]; then
         echo "Network Configured, waiting for reconnection"
-        sleep 15
+        while ! grep "default" <<< "$(ip route)"; do
+          sleep 1
+        done
+        # Service may timeout here waiting for connection
     else
         echo "No Networks Configured"
     fi
-    ip route | grep default
 fi
-if [ $? != 0 ]; then
+if ! grep "default" <<< "$(ip route)" ; then
   echo "Network not connected."
   if [ -f "/opt/neon/reset_clock" ]; then
     echo "Reset time on first boot without networking"
     /usr/bin/date -s "1 JAN 1970 00:00:00"
   fi
 else
-  echo "Connected; force sync"
-  /usr/sbin/ntpd -ngq
+  ntpd -gq
 fi
 
 [ -f "/opt/neon/reset_clock" ] && rm /opt/neon/reset_clock
+exit 0

--- a/overlays/27-update-clock/usr/lib/systemd/system/update-clock.service
+++ b/overlays/27-update-clock/usr/lib/systemd/system/update-clock.service
@@ -7,7 +7,8 @@ Requires=network.target
 [Service]
 Type=oneshot
 User=root
-ExecStart=/bin/bash /opt/neon/check_clock.sh
+ExecStart=/opt/neon/check_clock
+TimeoutStartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/overlays/41-neon-core/usr/lib/systemd/system/neon-logs.service
+++ b/overlays/41-neon-core/usr/lib/systemd/system/neon-logs.service
@@ -2,6 +2,7 @@
 Description=Neon Log Archival
 PartOf=neon.service
 Before=neon-bus.service
+After=update-clock.service
 
 [Service]
 Type=oneshot

--- a/overlays/41-neon-core/usr/lib/systemd/system/neon.service
+++ b/overlays/41-neon-core/usr/lib/systemd/system/neon.service
@@ -3,6 +3,7 @@ Description=Neon A.I. Software stack.
 After=pulseaudio.service
 After=preflight-check.service
 After=basic.target
+After=update-clock.service
 
 [Service]
 Type=oneshot

--- a/recipes/27-update-clock.yml
+++ b/recipes/27-update-clock.yml
@@ -9,4 +9,6 @@ actions:
   - action: run
     description: Enable clock reset service
     chroot: true
-    command: systemctl enable update-clock
+    command: |
+      chmod ugo+x /opt/neon/check_clock
+      systemctl enable update-clock

--- a/scripts/13-audio-devices.sh
+++ b/scripts/13-audio-devices.sh
@@ -52,11 +52,6 @@ rm -rf /tmp/tinyalsa
 cd /tmp
 git clone https://github.com/openvoiceos/ovos-i2csound
 
-# Patching compat with Kernel 6.6-specific changes
-cd ovos-i2csound
-git reset --hard 7215db7
-cd ..
-
 cp ovos-i2csound/i2c.conf /etc/modules-load.d/
 cp ovos-i2csound/ovos-i2csound /usr/libexec/
 cp ovos-i2csound/99-i2c.rules /usr/lib/udev/rules.d/


### PR DESCRIPTION
# Description
Cleanup `check_clock` script to complete faster and more accurately
Updates service dependencies to ensure clock updates complete before ntp service
Updates service dependencies to ensure clock is updated before Neon Core/logs are touched

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->