### PR TITLE
Refactor `apt` dependency from shell script to Debos recipe

### DIFF
--- a/recipes/46-audio-receiver.yml
+++ b/recipes/46-audio-receiver.yml
@@ -7,6 +7,7 @@ actions:
   - action: apt
     description: Audio Receiver Dependencies
     packages:
+      - curl
       - uxplay # AirPlay
       - kdeconnect # KDE Connect
       - "bluez*" # Bluetooth

--- a/scripts/46-audio-receiver.sh
+++ b/scripts/46-audio-receiver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export LIBRESPOT_NAME=${1:-"Neon Mark 2"}
 # Raspotify installation script
-apt-get -y install curl && curl -sL https://dtcooper.github.io/raspotify/install.sh -o install.sh
+curl -sL https://dtcooper.github.io/raspotify/install.sh -o install.sh
 ## Sudo causes issues in build VM, so strip it out
 sed -i '/SUDO="sudo"/c\SUDO=""' install.sh
 sh install.sh


### PR DESCRIPTION
# Description
Move curl installation to `apt` action instead of shell script for clearer organization

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->