### PR TITLE
Update image size for sector alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 overlays/80-google-json-overlay/**
 base_images/*.tar.gz
+output/
 .DS_Store

--- a/recipes/99-finalize_squashfs.yml
+++ b/recipes/99-finalize_squashfs.yml
@@ -9,7 +9,7 @@ actions:
 {{ if eq $platform "rpi4" }}
   - action: image-partition
     imagename: output/{{ $image }}.img
-    imagesize: 3.5GB
+    imagesize: 3.5GiB
     partitiontype: msdos
     diskid: 1242d180
     mountpoints:
@@ -32,7 +32,7 @@ actions:
 {{ else }}
   - action: image-partition
     imagename: output/{{ $image }}.img
-    imagesize: 3.5GB
+    imagesize: 3.5GiB
     partitiontype: gpt
     diskid: 67d9d0ad-c9a4-a94a-b477-ce3a3e8534e9
     mountpoints:


### PR DESCRIPTION
# Description
Update images to 3.5GiB for sector alignment
Update .gitignore to prevent including output images in repository

# Issues
Closes #179

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->